### PR TITLE
Set cache-control header to invalidate GitHub cache

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -23,6 +23,7 @@ export function createServer (axios: AxiosStatic, redisClient: RedisClientWrappe
 
     try {
       const badge = await getBadgeImage(axios, redisClient, subject || DEFAULT_SUBJECT, lastVersion, color || DEFAULT_COLOR, format, style);
+      res.set('Cache-Control', 'public, max-age=43200'); // 12 hours
       res.contentType(format).send(badge);
     } catch {
       res.status(500).end();


### PR DESCRIPTION
GitHub heavily caches page content which means more often than not the image displayed for the Maven badge on a project page is out of date, using the same "TTL" as Redis.