### PR TITLE
Update Badges to use new search.maven.org

### DIFF
--- a/src/services/mavenCentral.ts
+++ b/src/services/mavenCentral.ts
@@ -31,4 +31,4 @@ export const getArtifactDetailsUrl = (groupId: string, artifact: string, version
   `${BASE_URI}/artifact/${groupId}/${artifact}/${version}/jar`; // it would be ideal to pass in a extension here, as you could have situations like war, etc...
 
 export const getSearchByGaUrl = (groupId: string, artifact: string) =>
-  `${BASE_URI}/search?g:"${groupId}"%20AND%20a:"${artifact}&core=gav"`;
+  `${BASE_URI}/search?g:${groupId}%20AND%20a:${artifact}&core=gav`;

--- a/src/services/mavenCentral.ts
+++ b/src/services/mavenCentral.ts
@@ -1,6 +1,6 @@
 import { AxiosStatic } from 'axios';
 
-const BASE_URI = 'http://search.maven.org';
+const BASE_URI = 'https://search.maven.org';
 
 class NotFoundErrror extends Error {
   response = { status: 404 };
@@ -28,7 +28,7 @@ export const getDefinedArtifactVersion = async (axios: AxiosStatic, groupId: str
 };
 
 export const getArtifactDetailsUrl = (groupId: string, artifact: string, version: string) =>
-  `${BASE_URI}/#artifactdetails%7C${groupId}%7C${artifact}%7C${version}%7C`;
+  `${BASE_URI}/artifact/${groupId}/${artifact}/${version}/jar`; // it would be ideal to pass in a extension here, as you could have situations like war, etc...
 
 export const getSearchByGaUrl = (groupId: string, artifact: string) =>
-  `${BASE_URI}/#search%7Cga%7C1%7Cg:"${groupId}"a:"${artifact}"`;
+  `${BASE_URI}/search?g:"${groupId}"%20AND%20a:"${artifact}&core=gav"`;

--- a/src/test/http.spec.ts
+++ b/src/test/http.spec.ts
@@ -12,7 +12,7 @@ describe('http endpoints', () => {
   before(done => {
     const mockAxios = new MockAdapter(axios);
     mockAxios
-      .onGet('http://search.maven.org/solrsearch/select?q=g:"com.typesafe.akka"a:"akka"&rows=1&wt=json')
+      .onGet('https://search.maven.org/solrsearch/select?q=g:"com.typesafe.akka"a:"akka"&rows=1&wt=json')
       .reply(200, { response: { numFound: 1, docs: [{ latestVersion: '2.2.0-RC2' }] } });
     mockAxios
       .onGet(/http:\/\/img.shields.io\/badge\/maven_central-2.2.0--RC2-brightgreen.(png|svg)\?style=default/)
@@ -68,14 +68,14 @@ describe('http endpoints', () => {
     it('should redirect to maven artifact details page', done => {
       request
       .get(`/${PATH_PREFIX}/com.typesafe.akka/akka/?`)
-      .expect('location', 'http://search.maven.org/#artifactdetails%7Ccom.typesafe.akka%7Cakka%7C2.2.0-RC2%7C')
+      .expect('location', 'https://search.maven.org/#artifactdetails%7Ccom.typesafe.akka%7Cakka%7C2.2.0-RC2%7C')
       .expect(302, done);
     });
 
     it('should redirect to maven search page', done => {
       request
       .get(`/${PATH_PREFIX}/non.existing/artifact?`)
-      .expect('location', 'http://search.maven.org/#search%7Cga%7C1%7Cg:%22non.existing%22a:%22artifact%22')
+      .expect('location', 'https://search.maven.org/#search%7Cga%7C1%7Cg:%22non.existing%22a:%22artifact%22')
       .expect(302, done);
     });
   });

--- a/src/test/http.spec.ts
+++ b/src/test/http.spec.ts
@@ -75,7 +75,7 @@ describe('http endpoints', () => {
     it('should redirect to maven search page', done => {
       request
       .get(`/${PATH_PREFIX}/non.existing/artifact?`)
-      .expect('location', 'https://search.maven.org/search?g:non.existing%20AND%20a:%22artifact%22&core=gav')
+      .expect('location', 'https://search.maven.org/search?g:non.existing%20AND%20a:artifact&core=gav')
       .expect(302, done);
     });
   });

--- a/src/test/http.spec.ts
+++ b/src/test/http.spec.ts
@@ -68,14 +68,14 @@ describe('http endpoints', () => {
     it('should redirect to maven artifact details page', done => {
       request
       .get(`/${PATH_PREFIX}/com.typesafe.akka/akka/?`)
-      .expect('location', 'https://search.maven.org/#artifactdetails%7Ccom.typesafe.akka%7Cakka%7C2.2.0-RC2%7C')
+      .expect('location', 'https://search.maven.org/artifact/com.typesafe.akka/akka/2.2.0-RC2/jar')
       .expect(302, done);
     });
 
     it('should redirect to maven search page', done => {
       request
       .get(`/${PATH_PREFIX}/non.existing/artifact?`)
-      .expect('location', 'https://search.maven.org/#search%7Cga%7C1%7Cg:%22non.existing%22a:%22artifact%22')
+      .expect('location', 'https://search.maven.org/search?g:non.existing%20AND%20a:%22artifact%22&core=gav')
       .expect(302, done);
     });
   });


### PR DESCRIPTION
Hi there,

This is a PR that should update your badges to point at the new search.maven.org

I wouldn't merge it immediately, I've made a note in there that we also pass in extension to the new URL now, I defaulted that to jar, but there are likely cases out there where people have a war, etc...

This should address #20 

Cheers