### PR TITLE
sets Cache-Control response header to 'no-cache'

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -23,7 +23,7 @@ export function createServer (axios: AxiosStatic, redisClient: RedisClientWrappe
 
     try {
       const badge = await getBadgeImage(axios, redisClient, subject || DEFAULT_SUBJECT, lastVersion, color || DEFAULT_COLOR, format, style);
-      res.set('Cache-Control', 'public, max-age=43200'); // 12 hours
+      res.set('Cache-Control', 'no-cache');
       res.contentType(format).send(badge);
     } catch {
       res.status(500).end();


### PR DESCRIPTION
Several problems with images cached by github are still being reported (eg. [sttp](https://github.com/softwaremill/sttp)) so this is an attempt to fix that situation by using `Cache-Control: no-cache`. 